### PR TITLE
Allow animationLength prop to be changed

### DIFF
--- a/__tests__/fade-props-test.js
+++ b/__tests__/fade-props-test.js
@@ -42,12 +42,12 @@ test('removes the old child and renders the next child after 1000ms', () => {
   const first = <div key="first">First</div>;
   const second = <div key="second">Second</div>;
   
-  const fadeProps = ReactDOM.render(<FadeProps animationLength={1000}>{first}</FadeProps>, node);
+  const fadeProps = ReactDOM.render(<FadeProps>{first}</FadeProps>, node);
   const fadePropsNode = ReactDOM.findDOMNode(fadeProps);
   
   expect(fadePropsNode.textContent).toBe('First');
   
-  ReactDOM.render(<FadeProps>{second}</FadeProps>, node)
+  ReactDOM.render(<FadeProps animationLength={1000}>{second}</FadeProps>, node)
   expect(fadePropsNode.textContent).not.toBe('Second');
   
   jest.runAllTimers();

--- a/src/App.js
+++ b/src/App.js
@@ -8,19 +8,24 @@ class App extends Component {
       <div key="one">One</div>,
       <div key="two">Two</div>,
       <div key="three">Three</div>
-    ]
+    ],
+    animationLength: 2000
   };
   
   selectComponent(selected) {
     this.setState({ selected });
   }
+
+  handleAnimationLengthChange(event) {
+    this.setState({ animationLength: event.target.value });
+  }
   
   render() {
-    const { components, selected } = this.state;
+    const { components, selected, animationLength } = this.state;
     
     return (
       <div className="App">
-        <FadeProps animationLength={2000}>
+        <FadeProps animationLength={animationLength}>
           { components[selected] }
         </FadeProps>
         
@@ -39,6 +44,16 @@ class App extends Component {
         <button onClick={this.selectComponent.bind(this)}>
           Unload
         </button>
+
+        <div style={{ marginTop: 20 }}>
+          <label htmlFor="animation-length" style={{ marginRight: 10 }}>Animation Length</label>
+          <input
+            id="animation-length"
+            type="integer"
+            value={this.state.animationLength}
+            onChange={this.handleAnimationLengthChange.bind(this)}
+          />
+        </div>
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ class App extends Component {
   }
 
   handleAnimationLengthChange(event) {
-    this.setState({ animationLength: event.target.value });
+    this.setState({ animationLength: Number(event.target.value) });
   }
   
   render() {
@@ -49,7 +49,7 @@ class App extends Component {
           <label htmlFor="animation-length" style={{ marginRight: 10 }}>Animation Length</label>
           <input
             id="animation-length"
-            type="integer"
+            type="number"
             value={this.state.animationLength}
             onChange={this.handleAnimationLengthChange.bind(this)}
           />

--- a/src/fade-props.js
+++ b/src/fade-props.js
@@ -10,6 +10,10 @@ class FadeProps extends Component {
     animationLength: PropTypes.number
   };
 
+  static defaultProps = {
+    animationLength: DEFAULT_ANIMATION_LENGTH
+  };
+
   constructor(props) {
     super(props);
 
@@ -18,7 +22,6 @@ class FadeProps extends Component {
       : null;
 
     this.state = {
-      animationLength: props.animationLength || DEFAULT_ANIMATION_LENGTH,
       currentChild,
       /* Direction determines the opacity; if fading out, we set the opacity to 0,
       * if fading in, we set the opacity to 1 */
@@ -53,7 +56,7 @@ class FadeProps extends Component {
     /* If timeoutId is not set, then no fade is currently in progress, so let's
      * start the fade! */
     if (!this.timeoutId) {
-      this.timeoutId = setTimeout(this.queueNextChild, this.state.animationLength);
+      this.timeoutId = setTimeout(this.queueNextChild, this.props.animationLength);
       this.setState(({direction}) => ({ direction: +!direction }));
       return;
     }
@@ -78,7 +81,8 @@ class FadeProps extends Component {
   };
 
   render() {
-    const { direction, animationLength, currentChild } = this.state;
+    const { direction, currentChild } = this.state;
+    const { animationLength } = this.props;
 
     return (
       <div


### PR DESCRIPTION
## Current Behaviour
The initial value of the `animationLength` prop is store in the component's state in the constructor and is never updated. This means that changing the prop value has no effect.

## Proposed Change
This PR no longer keeps `animationLength` in the state and instead uses the current value of the prop. This allows components rendering FadeProps to pass in a new value if they want the length of the animation to change for any reason.

This also fixes a bug in following line, which prevents `animationLength` from being set to 0:
```
animationLength: props.animationLength || DEFAULT_ANIMATION_LENGTH,
```
Using `defaultProps` avoids this issue.

It also adds an input box to the demo App that sets the animation length.